### PR TITLE
Implement minimal real data ETL pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ repo/
 
     评分步骤会写入 `state/done_YYYY-MM-DD` 文件。删除该文件，或运行 `python scoring/run_scores.py --force` 来重新生成当天的报告。
 
+### 配置真实数据 API
+
+`etl/run_fetch.py` 会优先尝试调用真实的数据源：
+
+- Alpha Vantage：用于抓取 SPX/NDX 指数代理与 AI/防御板块 ETF 的最新收盘价与涨跌幅。
+- Coinbase / OKX：分别提供 BTC 现货、永续合约资金费率与基差。
+- Farside Investors：解析现货 ETF 表格获取最近一天的净申赎额。
+- Trading Economics：拉取接下来三天的宏观/事件日历。
+
+将上游凭证序列化为 JSON 放入 `API_KEYS` 环境变量即可：
+
+```bash
+export API_KEYS='{"alpha_vantage": "YOUR_ALPHA_KEY", "trading_economics": "user:password"}'
+```
+
+如果缺少密钥或接口超时，脚本会自动回退到内置的模拟数据，并在 `out/etl_status.json` 中标记失败项。
+
 ## 运行测试
 
 首先安装用于开发的额外依赖，然后使用 `uv run` (或在已激活的虚拟环境中直接使用 `pytest`) 来执行覆盖核心评分和简报生成助手的轻量级单元测试：
@@ -97,6 +114,61 @@ uv run pytest
 | 原始数据文件 `FileNotFoundError` | 确保在运行评分/简报步骤之前，`etl/run_fetch.py` 已成功执行。 |
 | 简报显示的是旧内容 | 删除 `state/done_YYYY-MM-DD` 文件，并使用 `--force` 选项重新运行评分脚本。 |
 | 飞书 Webhook 拒绝请求 | 仔细检查签名密钥，并确保机器人已开启接收交互式卡片消息的权限。 |
+
+## 真实数据源接入建议
+
+参考下列数据供应商和搭配方案，可以让项目从“模拟/假数据”平滑迁移到可上线的真实行情：
+
+### 指数 / 股票行情与板块代理
+
+- **[Polygon.io](https://polygon.io/docs?utm_source=chatgpt.com)**：覆盖股票、期权、期货、外汇与指数，提供 REST 与 WebSocket 接口，连指数的分钟级聚合也能拉取。适合用各类 ETF 作为板块代理（例如 XAR/ITA 表示军工，XLK 表示科技）。
+- **[Alpha Vantage](https://www.alphavantage.co/documentation/?utm_source=chatgpt.com)**：免费层即可获取股票 / ETF 的历史及日内 K 线，足够做原型，但频控较严。
+- **[Tiingo](https://www.tiingo.com/?utm_source=chatgpt.com)**：EOD、日内行情、新闻与加密货币数据俱全，质量稳定，是纯免费方案的升级版。
+
+### 比特币现货价格与交易所数据
+
+- **[Coinbase Advanced Trade API](https://docs.cdp.coinbase.com/advanced-trade/docs/welcome?utm_source=chatgpt.com)**：官方现货行情与订单流，文档完整，还提供 SDK，适合拿来作为“现货腿”参与基差计算。
+
+### 资金费率（Funding）与永续合约
+
+- **[Binance USDⓈ-M 期货 API](https://developers.binance.com/docs/derivatives/usds-margined-futures/market-data/rest-api/Get-Funding-Rate-History?utm_source=chatgpt.com)**：`/fapi/v1/fundingRate` 提供历史资金费率，覆盖面广，官方示例多。
+- **[Deribit 公共 API](https://docs.deribit.com/?utm_source=chatgpt.com)**：包含 “perpetual funding rate” 历史接口，适合做多交易所对比或对冲。
+
+### 期货价格与基差（CME 比特币期货）
+
+- **[CME Group 实时数据 API](https://www.cmegroup.com/market-data/real-time-futures-and-options-data-api.html?utm_source=chatgpt.com)**：官方实时行情流，是基差计算里“期货腿”的直接来源，但属于付费/许可数据。
+- **[CME DataMine](https://www.cmegroup.com/market-data/datamine-api.html?utm_source=chatgpt.com)**：可下载官方历史结算、成交量等，适合算日度基差，同样需要购买授权。
+- 如果仍在验证原型，可用 Coinbase 现货 + 任意能获取的 CME 延时/结算价跑通流程，之后再升级数据源。
+
+### 比特币现货 ETF 资金流（净申赎）
+
+- **[Farside Investors](https://farside.co.uk/btc/?utm_source=chatgpt.com)**：免费聚合多只美股比特币现货 ETF 的每日净流入/流出表格与图表，社区常用参考源。
+- **[iShares IBIT 官方页](https://www.blackrock.com/us/individual/products/333011/ishares-bitcoin-trust?utm_source=chatgpt.com)**：发行方披露信息，可作为校准基准。
+- 若需要更系统化的历史与多指标比对，可引入 Glassnode、Kaiko 等付费链上/市场数据商。
+
+### 经济与事件日历（宏观 / 财报）
+
+- **[Trading Economics Calendar API](https://tradingeconomics.com/api/calendar.aspx?utm_source=chatgpt.com)**：提供全球宏观日历，REST 接口简单易用。
+- **[Finnhub](https://finnhub.io/docs/api/earnings-calendar?utm_source=chatgpt.com)**：既有财报日历，也包含全球交易所假期接口，可拼成项目所需的“事件日历”模块。
+
+### 交易日 / 市场开闭市判断
+
+- **[Polygon Market Holidays](https://polygon.io/docs/rest/stocks/market-operations/market-holidays?utm_source=chatgpt.com)**：`/v1/marketstatus/upcoming` 返回未来假期与开闭市时间，用于保护定时任务。
+- **IEX / Finnhub**：可作为假期、交易日的备援数据源。
+
+### 落地拼装建议
+
+1. **先用免费或低成本源跑通 ETL**：例如现货用 Coinbase，ETF 流用 Farside，宏观日历用 Trading Economics，假期信息用 Polygon。
+2. **完成三大核心指标**：
+   - **板块 / 主题表现**：拉取对应 ETF 的收盘或日内数据并聚合（如科技 = XLK，军工 = ITA/XAR，AI = BOTZ/ROBO）。
+   - **资金费率**：使用 Binance 或 Deribit 的历史 funding rate 构建时间序列。
+   - **期货基差**：基差 = 期货近月价格 − 现货价格；年化基差 = (期货 / 现货 − 1) × 365 / 到期天数。期货价格来自 CME 实时或结算数据，现货价格来自 Coinbase。
+3. **需求稳定后升级为专业付费源**：逐步将 ETF/股票数据迁移至 Polygon/Tiingo，将期货数据升级为 CME 官方流或数据集，提前处理好授权与法务流程。
+
+### 版权与合规提醒
+
+- 大多数商用数据都限制再分发、长期缓存或展示粒度。上线前务必审阅条款，尤其是缓存或下游 API 的使用是否被允许。
+- 官方文档通常标注了许可范围，不要忽视相关说明。
 
 ## 测试思路
 

--- a/etl/run_fetch.py
+++ b/etl/run_fetch.py
@@ -12,13 +12,30 @@ import os
 import sys
 from dataclasses import dataclass, asdict
 from datetime import datetime, timedelta
+from html.parser import HTMLParser
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import pytz
+import requests
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 OUT_DIR = BASE_DIR / "out"
+
+ALPHA_VANTAGE_SYMBOLS = {
+    "SPX": "SPY",  # S&P 500 ETF proxy
+    "NDX": "QQQ",  # Nasdaq 100 ETF proxy
+}
+
+SECTOR_PROXIES = {
+    "AI": "BOTZ",  # Robotics & AI ETF
+    "Defensive": "XLP",  # Consumer staples ETF
+}
+
+TE_GUEST_CREDENTIAL = "guest:guest"
+
+REQUEST_TIMEOUT = 15
+USER_AGENT = "daily-messenger-bot/0.1"
 
 
 @dataclass
@@ -47,6 +64,272 @@ def _load_api_keys() -> Dict[str, Any]:
     except json.JSONDecodeError as exc:
         print("API_KEYS 无法解析为 JSON: %s" % exc, file=sys.stderr)
         return {}
+
+
+def _request_json(url: str, *, params: Optional[Dict[str, Any]] = None, headers: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+    hdrs = {"User-Agent": USER_AGENT}
+    if headers:
+        hdrs.update(headers)
+    resp = requests.get(url, params=params, headers=hdrs, timeout=REQUEST_TIMEOUT)
+    resp.raise_for_status()
+    return resp.json()
+
+
+class _HTMLTableParser(HTMLParser):
+    """Extract rows from a simple HTML table."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._capture = False
+        self._buffer: List[str] = []
+        self._current: List[str] = []
+        self.rows: List[List[str]] = []
+
+    def handle_starttag(self, tag: str, attrs: List[Tuple[str, Optional[str]]]) -> None:  # type: ignore[override]
+        if tag == "tr":
+            self._current = []
+        elif tag in {"td", "th"}:
+            self._capture = True
+            self._buffer = []
+
+    def handle_endtag(self, tag: str) -> None:  # type: ignore[override]
+        if tag in {"td", "th"} and self._capture:
+            value = "".join(self._buffer).strip()
+            self._current.append(value)
+            self._capture = False
+        elif tag == "tr" and self._current:
+            self.rows.append(self._current)
+
+    def handle_data(self, data: str) -> None:  # type: ignore[override]
+        if self._capture:
+            self._buffer.append(data)
+
+
+def _parse_number(value: str) -> Optional[float]:
+    text = value.strip()
+    if not text or text == "-":
+        return None
+    negative = text.startswith("(") and text.endswith(")")
+    text = text.strip("() ")
+    normalized = text.replace(",", "").replace("\u2212", "-")
+    try:
+        number = float(normalized)
+    except ValueError:
+        return None
+    return -number if negative else number
+
+
+def _latest_date(rows: Iterable[List[str]]) -> Optional[List[str]]:
+    parsed: List[Tuple[datetime, List[str]]] = []
+    for row in rows:
+        if not row:
+            continue
+        first = row[0].strip()
+        try:
+            parsed_date = datetime.strptime(first, "%d %b %Y")
+        except ValueError:
+            continue
+        parsed.append((parsed_date, row))
+    if not parsed:
+        return None
+    parsed.sort(key=lambda item: item[0], reverse=True)
+    return parsed[0][1]
+
+
+def _fetch_farside_latest_flow() -> Tuple[Optional[float], FetchStatus]:
+    url = "https://farside.co.uk/wp-json/wp/v2/pages"
+    try:
+        payload = _request_json(url, params={"slug": "bitcoin-etf-flow-all-data"})
+    except Exception as exc:  # noqa: BLE001
+        return None, FetchStatus(name="btc_etf_flow", ok=False, message=f"Farside 请求失败: {exc}")
+
+    if not payload:
+        return None, FetchStatus(name="btc_etf_flow", ok=False, message="Farside 未返回内容")
+
+    content = payload[0].get("content", {}).get("rendered", "")
+    parser = _HTMLTableParser()
+    parser.feed(content)
+    latest = _latest_date(parser.rows)
+    if not latest:
+        return None, FetchStatus(name="btc_etf_flow", ok=False, message="未能解析 ETF 流入数据")
+
+    total = latest[-1] if latest else None
+    amount = _parse_number(total or "")
+    if amount is None:
+        return None, FetchStatus(name="btc_etf_flow", ok=False, message="ETF 流入字段为空")
+
+    return amount, FetchStatus(name="btc_etf_flow", ok=True, message="ETF 净流入读取成功")
+
+
+def _fetch_coinbase_spot() -> Tuple[Optional[float], FetchStatus]:
+    url = "https://api.coinbase.com/v2/prices/BTC-USD/spot"
+    try:
+        payload = _request_json(url)
+    except Exception as exc:  # noqa: BLE001
+        return None, FetchStatus(name="coinbase_spot", ok=False, message=f"Coinbase 请求失败: {exc}")
+
+    try:
+        amount = float(payload["data"]["amount"])
+    except (KeyError, TypeError, ValueError) as exc:
+        return None, FetchStatus(name="coinbase_spot", ok=False, message=f"Coinbase 响应解析失败: {exc}")
+
+    return amount, FetchStatus(name="coinbase_spot", ok=True, message="Coinbase 现货价格已获取")
+
+
+def _fetch_okx_funding() -> Tuple[Optional[float], FetchStatus]:
+    url = "https://www.okx.com/api/v5/public/funding-rate"
+    try:
+        payload = _request_json(url, params={"instId": "BTC-USD-SWAP"})
+    except Exception as exc:  # noqa: BLE001
+        return None, FetchStatus(name="okx_funding", ok=False, message=f"OKX 请求失败: {exc}")
+
+    if payload.get("code") != "0":
+        return None, FetchStatus(name="okx_funding", ok=False, message=f"OKX 返回错误: {payload.get('msg')}")
+
+    data = payload.get("data") or []
+    if not data:
+        return None, FetchStatus(name="okx_funding", ok=False, message="OKX 未返回资金费率")
+
+    try:
+        rate = float(data[0]["fundingRate"])
+    except (KeyError, TypeError, ValueError) as exc:
+        return None, FetchStatus(name="okx_funding", ok=False, message=f"资金费率解析失败: {exc}")
+
+    return rate, FetchStatus(name="okx_funding", ok=True, message="OKX 资金费率已获取")
+
+
+def _fetch_okx_basis(spot_price: float) -> Tuple[Optional[float], FetchStatus]:
+    url = "https://www.okx.com/api/v5/market/ticker"
+    try:
+        payload = _request_json(url, params={"instId": "BTC-USD-SWAP"})
+    except Exception as exc:  # noqa: BLE001
+        return None, FetchStatus(name="okx_basis", ok=False, message=f"OKX ticker 请求失败: {exc}")
+
+    if payload.get("code") != "0":
+        return None, FetchStatus(name="okx_basis", ok=False, message=f"OKX 返回错误: {payload.get('msg')}")
+
+    data = payload.get("data") or []
+    if not data:
+        return None, FetchStatus(name="okx_basis", ok=False, message="OKX 未返回永续价格")
+
+    try:
+        last_price = float(data[0]["last"])
+    except (KeyError, TypeError, ValueError) as exc:
+        return None, FetchStatus(name="okx_basis", ok=False, message=f"永续价格解析失败: {exc}")
+
+    if spot_price <= 0:
+        return None, FetchStatus(name="okx_basis", ok=False, message="现货价格无效，无法计算基差")
+
+    basis = (last_price - spot_price) / spot_price
+    return basis, FetchStatus(name="okx_basis", ok=True, message="已计算 OKX 永续基差")
+
+
+def _fetch_alpha_series(symbol: str, api_key: str) -> Dict[str, Any]:
+    url = "https://www.alphavantage.co/query"
+    params = {
+        "function": "TIME_SERIES_DAILY",
+        "symbol": symbol,
+        "apikey": api_key,
+    }
+    payload = _request_json(url, params=params)
+    key = next((k for k in payload if "Time Series" in k), None)
+    if not key:
+        message = payload.get("Information") or payload.get("Note") or "Alpha Vantage 未返回时间序列"
+        raise RuntimeError(message)
+    return payload[key]
+
+
+def _extract_close_change(series: Dict[str, Dict[str, str]]) -> Tuple[str, float, float]:
+    dates = sorted(series.keys(), reverse=True)
+    if len(dates) < 2:
+        raise RuntimeError("时间序列不足以计算涨跌幅")
+    latest, prev = dates[0], dates[1]
+    close = float(series[latest]["4. close"])
+    prev_close = float(series[prev]["4. close"])
+    change_pct = (close - prev_close) / prev_close * 100
+    return latest, close, change_pct
+
+
+def _extract_performance(series: Dict[str, Dict[str, str]]) -> float:
+    _, close, change_pct = _extract_close_change(series)
+    return 1 + change_pct / 100
+
+
+def _fetch_market_snapshot_real(api_keys: Dict[str, Any]) -> Tuple[Optional[Dict[str, Any]], FetchStatus]:
+    api_key = api_keys.get("alpha_vantage")
+    if not api_key:
+        return None, FetchStatus(name="market", ok=False, message="缺少 Alpha Vantage API Key")
+
+    try:
+        index_data = {
+            symbol: _fetch_alpha_series(proxy, api_key) for symbol, proxy in ALPHA_VANTAGE_SYMBOLS.items()
+        }
+        sector_data = {
+            name: _fetch_alpha_series(proxy, api_key) for name, proxy in SECTOR_PROXIES.items()
+        }
+    except Exception as exc:  # noqa: BLE001
+        return None, FetchStatus(name="market", ok=False, message=f"Alpha Vantage 请求失败: {exc}")
+
+    latest_date = None
+    indices: List[Dict[str, Any]] = []
+    for symbol, series in index_data.items():
+        day, close, change_pct = _extract_close_change(series)
+        latest_date = latest_date or day
+        indices.append({"symbol": symbol, "close": round(close, 2), "change_pct": round(change_pct, 2)})
+
+    sectors: List[Dict[str, Any]] = []
+    for name, series in sector_data.items():
+        perf = _extract_performance(series)
+        sectors.append({"name": name, "performance": round(perf, 3)})
+
+    market = {
+        "date": latest_date,
+        "indices": indices,
+        "sectors": sectors,
+    }
+    return market, FetchStatus(name="market", ok=True, message="Alpha Vantage 行情已获取")
+
+
+def _fetch_events_real(trading_day: str, api_keys: Dict[str, Any]) -> Tuple[List[Dict[str, Any]], FetchStatus]:
+    credential = api_keys.get("trading_economics", TE_GUEST_CREDENTIAL)
+    params = {"c": credential, "format": "json"}
+    try:
+        payload = _request_json("https://api.tradingeconomics.com/calendar", params=params)
+    except Exception as exc:  # noqa: BLE001
+        return [], FetchStatus(name="events", ok=False, message=f"Trading Economics 请求失败: {exc}")
+
+    base_date = datetime.strptime(trading_day, "%Y-%m-%d").date()
+    window_end = base_date + timedelta(days=5)
+    events: List[Dict[str, Any]] = []
+    for entry in payload:
+        date_str = entry.get("Date")
+        event_name = entry.get("Event")
+        if not date_str or not event_name:
+            continue
+        try:
+            event_date = datetime.fromisoformat(date_str.replace("Z", "+00:00")).date()
+        except ValueError:
+            continue
+        if not (base_date <= event_date <= window_end):
+            continue
+        importance = str(entry.get("Importance", "medium")).lower()
+        if importance not in {"low", "medium", "high"}:
+            importance = "medium"
+        events.append(
+            {
+                "title": event_name,
+                "date": event_date.strftime("%Y-%m-%d"),
+                "impact": importance,
+                "country": entry.get("Country"),
+            }
+        )
+        if len(events) >= 8:
+            break
+
+    if not events:
+        return [], FetchStatus(name="events", ok=False, message="Trading Economics 未返回可用事件")
+
+    return events, FetchStatus(name="events", ok=True, message="Trading Economics 事件日历已获取")
 
 
 def _simulate_market_snapshot(trading_day: str) -> Tuple[Dict[str, Any], FetchStatus]:
@@ -116,14 +399,55 @@ def run() -> int:
         print("未提供 API 密钥，将使用示例数据。")
 
     statuses: List[FetchStatus] = []
-    market_data, status = _simulate_market_snapshot(trading_day)
-    statuses.append(status)
+    overall_ok = True
 
-    btc_data, status = _simulate_btc_theme(trading_day)
+    market_data, status = _fetch_market_snapshot_real(api_keys)
     statuses.append(status)
+    if not status.ok:
+        overall_ok = False
+        fallback, fallback_status = _simulate_market_snapshot(trading_day)
+        market_data = fallback
+        statuses.append(fallback_status)
 
-    events, status = _simulate_events(trading_day)
-    statuses.append(status)
+    spot_price, spot_status = _fetch_coinbase_spot()
+    statuses.append(spot_status)
+
+    funding_rate, funding_status = _fetch_okx_funding()
+    statuses.append(funding_status)
+
+    basis = None
+    basis_status: Optional[FetchStatus] = None
+    if spot_price is not None:
+        basis, basis_status = _fetch_okx_basis(spot_price)
+        statuses.append(basis_status)
+    else:
+        statuses.append(FetchStatus(name="okx_basis", ok=False, message="缺少现货价格，无法计算基差"))
+
+    etf_flow, flow_status = _fetch_farside_latest_flow()
+    statuses.append(flow_status)
+
+    btc_data: Dict[str, Any]
+    if spot_price is not None and funding_rate is not None and basis is not None and etf_flow is not None:
+        btc_data = {
+            "date": trading_day,
+            "spot_price_usd": round(spot_price, 2),
+            "perpetual_price_usd": round(spot_price * (1 + basis), 2) if basis is not None else None,
+            "etf_net_inflow_musd": round(etf_flow, 2),
+            "funding_rate": round(funding_rate, 6),
+            "futures_basis": round(basis, 6),
+        }
+        statuses.append(FetchStatus(name="btc", ok=True, message="BTC 主题数据已获取"))
+    else:
+        overall_ok = False
+        btc_data, sim_status = _simulate_btc_theme(trading_day)
+        statuses.append(sim_status)
+
+    events, events_status = _fetch_events_real(trading_day, api_keys)
+    statuses.append(events_status)
+    if not events_status.ok:
+        fallback_events, fallback_status = _simulate_events(trading_day)
+        events = fallback_events
+        statuses.append(fallback_status)
 
     raw_market_path = OUT_DIR / "raw_market.json"
     raw_events_path = OUT_DIR / "raw_events.json"
@@ -138,7 +462,7 @@ def run() -> int:
     status_payload = {
         "date": trading_day,
         "sources": [asdict(s) for s in statuses],
-        "ok": all(s.ok for s in statuses),
+        "ok": overall_ok,
     }
     with status_path.open("w", encoding="utf-8") as f:
         json.dump(status_payload, f, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## Summary
- extend `etl/run_fetch.py` with live data fetchers for Alpha Vantage equities, Coinbase spot, OKX funding/basis, Farside ETF flows, and Trading Economics events with graceful fallbacks
- record detailed fetch statuses while only degrading the pipeline when core equity or BTC data must fall back to simulations
- document how to supply API keys for the new data sources in the README

## Testing
- `pytest` *(fails: missing optional dependencies `jinja2`, `yaml` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e133ecae248327ac61be795fdfab4a