### PR TITLE
Integrate additional market data sources and theme scoring

### DIFF
--- a/config/weights.yml
+++ b/config/weights.yml
@@ -11,6 +11,12 @@ weights:
     sentiment: 0.25
     liquidity: 0.2
     event: 0.1
+  theme_m7:
+    fundamental: 0.35
+    valuation: 0.2
+    sentiment: 0.2
+    liquidity: 0.15
+    event: 0.1
   theme_btc:
     fundamental: 0.1
     valuation: 0.15

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -28,6 +28,27 @@ def test_score_ai_produces_weighted_total():
     assert math.isclose(degraded_result.total, expected_total, rel_tol=1e-9)
 
 
+def test_score_magnificent7_uses_theme_metrics():
+    config = scoring._load_config()
+    weights = config["weights"]["theme_m7"]
+    market = {
+        "themes": {
+            "magnificent7": {
+                "change_pct": 1.2,
+                "avg_pe": 28.0,
+                "avg_ps": 6.5,
+                "market_cap": 12_000_000_000_000,
+            }
+        }
+    }
+
+    result = scoring._score_magnificent7(market, weights, degraded=False)
+
+    assert result.name == "magnificent7"
+    assert result.total >= 0
+    assert not result.degraded
+
+
 def test_build_actions_generates_expected_labels():
     thresholds = scoring._load_config()["thresholds"]
     high_theme = scoring.ThemeScore(


### PR DESCRIPTION
## Summary
- add a quick-reference table of free or free-tier APIs that cover equities, macro events, crypto metrics, sentiment, and AI news needs
- connect Twelve Data, Financial Modeling Prep, and Finnhub to the ETL to populate Hong Kong proxies, theme valuations, and upcoming earnings events
- surface a Magnificent 7 theme in scoring with dedicated weights and regression tests

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e13f870f1483279fe69fc82526f2e3