### PR TITLE
Add AI RSS and arXiv ingestion to ETL pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,32 @@ repo/
 
 * Trading Economics + Finnhub：拉取宏观事件与未来一周的财报日历，二者合并为统一事件流。
 
+* AI 新闻 RSS + arXiv：根据配置抓取 OpenAI、DeepMind 等 RSS 更新以及符合查询条件的最新 arXiv 论文。
+
 将上游凭证序列化为 JSON 放入 `API_KEYS` 环境变量即可：
 
 ```bash
-export API_KEYS='{"alpha_vantage": "YOUR_ALPHA_KEY", "trading_economics": "user:password", "twelve_data": "TD_KEY", "financial_modeling_prep": "FMP_KEY", "finnhub": "FINNHUB_TOKEN"}'
+export API_KEYS='{
+  "alpha_vantage": "YOUR_ALPHA_KEY",
+  "trading_economics": "user:password",
+  "twelve_data": "TD_KEY",
+  "financial_modeling_prep": "FMP_KEY",
+  "finnhub": "FINNHUB_TOKEN",
+  "ai_feeds": [
+    "https://openai.com/news/rss.xml",
+    "https://deepmind.com/blog/feed/basic"
+  ],
+  "arxiv": {
+    "search_query": "cat:cs.LG OR cat:cs.AI",
+    "max_results": 8,
+    "sort_by": "submittedDate",
+    "sort_order": "descending",
+    "throttle_seconds": 3
+  }
+}'
 ```
 
-如果缺少密钥或接口超时，脚本会自动回退到内置的模拟数据，并在 `out/etl_status.json` 中标记失败项。
+其中 `ai_feeds` 用于配置需要抓取的 AI 新闻 RSS 地址，`arxiv` 则控制 arXiv 检索的查询条件、返回数量及节流时间（单位：秒）。如果缺少密钥或接口超时，脚本会自动回退到内置的模拟数据，并在 `out/etl_status.json` 中标记失败项。
 
 ## 运行测试
 

--- a/tests/test_etl_ai_feeds.py
+++ b/tests/test_etl_ai_feeds.py
@@ -1,0 +1,208 @@
+import importlib
+import json
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def load_run_fetch(monkeypatch):
+    modules_cache = sys.modules
+
+    def _loader(api_keys):
+        if api_keys is None:
+            monkeypatch.delenv("API_KEYS", raising=False)
+        else:
+            monkeypatch.setenv("API_KEYS", json.dumps(api_keys))
+        if "etl.run_fetch" in modules_cache:
+            module = importlib.reload(modules_cache["etl.run_fetch"])
+        else:
+            module = importlib.import_module("etl.run_fetch")
+        return module
+
+    return _loader
+
+
+class DummyResponse:
+    def __init__(self, content: str, status_code: int = 200):
+        self.content = content.encode("utf-8")
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise Exception(f"status {self.status_code}")
+
+
+def test_fetch_ai_rss_events_parses_items(monkeypatch, load_run_fetch):
+    module = load_run_fetch(
+        {
+            "ai_feeds": [
+                "https://example.com/rss",  # success
+                "https://example.com/fail",  # failure
+            ]
+        }
+    )
+
+    rss_payload = """
+        <rss><channel>
+            <item>
+                <title>OpenAI Update</title>
+                <pubDate>Mon, 01 Apr 2024 10:00:00 GMT</pubDate>
+            </item>
+            <item>
+                <title>Another Story</title>
+                <pubDate>Tue, 02 Apr 2024 12:00:00 GMT</pubDate>
+            </item>
+        </channel></rss>
+    """
+
+    def fake_get(url, headers=None, timeout=None):
+        if "fail" in url:
+            raise module.requests.RequestException("boom")
+        return DummyResponse(rss_payload)
+
+    monkeypatch.setattr(module.requests, "get", fake_get)
+
+    events, statuses = module._fetch_ai_rss_events(module.AI_NEWS_FEEDS)
+    assert len(events) == 2
+    assert events[0]["source"] == "https://example.com/rss"
+    assert any(not status.ok for status in statuses)
+    assert any(status.ok for status in statuses)
+
+
+def test_fetch_arxiv_events_parses_entries(monkeypatch, load_run_fetch):
+    module = load_run_fetch({})
+
+    feed_payload = """
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <entry>
+                <title>Sample Paper</title>
+                <updated>2024-04-01T08:00:00Z</updated>
+            </entry>
+        </feed>
+    """
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        assert params["search_query"] == module.ARXIV_QUERY_PARAMS["search_query"]
+        return DummyResponse(feed_payload)
+
+    monkeypatch.setattr(module.requests, "get", fake_get)
+
+    events, status = module._fetch_arxiv_events(module.ARXIV_QUERY_PARAMS, 0)
+    assert status.ok
+    assert events[0]["title"].startswith("arXiv: Sample Paper")
+    assert events[0]["date"] == "2024-04-01"
+
+
+def test_run_includes_ai_sources(tmp_path, monkeypatch, load_run_fetch):
+    module = load_run_fetch(
+        {
+            "ai_feeds": ["https://example.com/rss"],
+            "arxiv": {
+                "search_query": "cat:cs.AI",
+                "max_results": 1,
+                "sort_by": "submittedDate",
+                "sort_order": "descending",
+                "throttle_seconds": 0,
+            },
+        }
+    )
+
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(module, "OUT_DIR", out_dir)
+
+    monkeypatch.setattr(
+        module,
+        "_fetch_market_snapshot_real",
+        lambda api_keys: ({}, module.FetchStatus(name="market", ok=True, message="ok")),
+    )
+    monkeypatch.setattr(
+        module,
+        "_simulate_market_snapshot",
+        lambda trading_day: ({}, module.FetchStatus(name="market_sim", ok=True, message="ok")),
+    )
+    monkeypatch.setattr(
+        module,
+        "_fetch_coinbase_spot",
+        lambda: (50000.0, module.FetchStatus(name="coinbase_spot", ok=True, message="ok")),
+    )
+    monkeypatch.setattr(
+        module,
+        "_fetch_okx_funding",
+        lambda: (0.001, module.FetchStatus(name="okx_funding", ok=True, message="ok")),
+    )
+    monkeypatch.setattr(
+        module,
+        "_fetch_okx_basis",
+        lambda spot_price: (0.0, module.FetchStatus(name="okx_basis", ok=True, message="ok")),
+    )
+    monkeypatch.setattr(
+        module,
+        "_fetch_farside_latest_flow",
+        lambda: (12.5, module.FetchStatus(name="btc_etf_flow", ok=True, message="ok")),
+    )
+    monkeypatch.setattr(
+        module,
+        "_simulate_btc_theme",
+        lambda trading_day: ({}, module.FetchStatus(name="btc_sim", ok=True, message="ok")),
+    )
+    monkeypatch.setattr(
+        module,
+        "_fetch_events_real",
+        lambda trading_day, api_keys: (
+            [
+                {
+                    "title": "宏观事件",
+                    "date": "2024-04-01",
+                    "impact": "high",
+                }
+            ],
+            module.FetchStatus(name="events", ok=True, message="ok"),
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "_fetch_finnhub_earnings",
+        lambda trading_day, api_keys: ([], module.FetchStatus(name="finnhub_earnings", ok=True, message="ok")),
+    )
+    monkeypatch.setattr(
+        module,
+        "_fetch_ai_rss_events",
+        lambda feeds: (
+            [
+                {
+                    "title": "RSS Event",
+                    "date": "2024-04-02",
+                    "impact": "medium",
+                    "source": feeds[0],
+                }
+            ],
+            [module.FetchStatus(name="ai_rss_1", ok=True, message="ok")],
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "_fetch_arxiv_events",
+        lambda params, throttle: (
+            [
+                {
+                    "title": "arXiv: Paper",
+                    "date": "2024-04-03",
+                    "impact": "low",
+                    "source": "arxiv",
+                }
+            ],
+            module.FetchStatus(name="arxiv", ok=True, message="ok"),
+        ),
+    )
+
+    result = module.run()
+    assert result == 0
+
+    raw_events_path = out_dir / "raw_events.json"
+    assert raw_events_path.exists()
+    payload = json.loads(raw_events_path.read_text(encoding="utf-8"))
+    titles = {event["title"] for event in payload["events"]}
+    assert "宏观事件" in titles
+    assert "RSS Event" in titles
+    assert "arXiv: Paper" in titles


### PR DESCRIPTION
## Summary
- add configurable AI RSS feed and arXiv query handling to the ETL configuration loader
- fetch, normalize, and merge RSS/arXiv events alongside existing Trading Economics and Finnhub data
- document the new configuration keys and cover the integration with dedicated unit tests

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5271686288327a6f772960bc4152b