### PR TITLE
Fix run_fetch relative import when run as a script

### DIFF
--- a/etl/run_fetch.py
+++ b/etl/run_fetch.py
@@ -22,7 +22,11 @@ from xml.etree import ElementTree as ET
 import pytz
 import requests
 
-from .fetchers import aaii_sentiment, cboe_putcall
+if __package__:
+    from .fetchers import aaii_sentiment, cboe_putcall
+else:  # pragma: no cover - runtime convenience for direct script execution
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    from etl.fetchers import aaii_sentiment, cboe_putcall
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 OUT_DIR = BASE_DIR / "out"


### PR DESCRIPTION
## Summary
- allow `etl/run_fetch.py` to be executed directly by adding a fallback absolute import for the fetchers module

## Testing
- python etl/run_fetch.py *(fails: ModuleNotFoundError: No module named 'pytz' in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e67141ae948327ba5d49c54d08d397