### PR TITLE
Improve market data fallbacks

### DIFF
--- a/etl/fetchers/cboe_putcall.py
+++ b/etl/fetchers/cboe_putcall.py
@@ -1,26 +1,29 @@
 """Fetch Cboe daily put/call ratios."""
 from __future__ import annotations
 
+import csv
 import datetime as dt
+import io
 import re
 from dataclasses import dataclass
-from html.parser import HTMLParser
-from typing import Dict, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import requests
 from zoneinfo import ZoneInfo
 
-USER_AGENT = "daily-messenger-bot/0.1"
+USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " "(KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36"
 REQUEST_TIMEOUT = 15
-URL = "https://www.cboe.com/us/options/market_statistics/daily/"
 EXCHANGE_TZ = ZoneInfo("America/Chicago")
 
-LABELS = {
-    "equity": "EQUITY PUT/CALL RATIO",
-    "index": "INDEX PUT/CALL RATIO",
-    "spx_spxw": "SPX + SPXW PUT/CALL RATIO",
-    "vix": "CBOE VOLATILITY INDEX (VIX) PUT/CALL RATIO",
+CSV_SOURCES: Dict[str, str] = {
+    "equity": "https://cdn.cboe.com/resources/options/volume_and_call_put_ratios/equitypc.csv",
+    "index": "https://cdn.cboe.com/resources/options/volume_and_call_put_ratios/indexpc.csv",
+    "spx_spxw": "https://cdn.cboe.com/resources/options/volume_and_call_put_ratios/spxpc.csv",
+    "vix": "https://cdn.cboe.com/resources/options/volume_and_call_put_ratios/vixpc.csv",
 }
+
+MARKET_SUMMARY_URL = "https://www.cboe.com/us/options/market_statistics/"
+TOTAL_PATTERN = re.compile(r"Total[^<]*P/C\s*RATIO[^0-9]*([0-9]+(?:\.[0-9]+)?)", re.IGNORECASE | re.DOTALL)
 
 
 @dataclass
@@ -30,65 +33,118 @@ class FetchStatus:
     message: str = ""
 
 
-class _TextExtractor(HTMLParser):
-    """Minimal HTML text extractor."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self._chunks: list[str] = []
-
-    def handle_data(self, data: str) -> None:  # type: ignore[override]
-        text = data.strip()
-        if text:
-            self._chunks.append(text)
-
-    def get_text(self) -> str:
-        return " ".join(self._chunks)
+def _init_session() -> requests.Session:
+    session = requests.Session()
+    session.headers.update({"User-Agent": USER_AGENT})
+    try:
+        session.get("https://www.cboe.com", timeout=REQUEST_TIMEOUT)
+    except Exception:  # noqa: BLE001 - warm-up best effort
+        pass
+    return session
 
 
-def _extract_numbers(text: str) -> Dict[str, float]:
-    results: Dict[str, float] = {}
-    for key, label in LABELS.items():
-        pattern = re.compile(rf"{re.escape(label)}[^0-9]*([0-9]+(?:\.[0-9]+)?)", re.IGNORECASE)
-        match = pattern.search(text)
-        if match:
-            try:
-                results[key] = float(match.group(1))
-            except ValueError:
-                continue
-    return results
+def _parse_ratio(value: str) -> Optional[float]:
+    text = value.strip().replace("%", "")
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _latest_csv_row(content: str) -> Tuple[str, float]:
+    reader = csv.reader(io.StringIO(content))
+    latest_date: Optional[dt.date] = None
+    latest_ratio: Optional[float] = None
+    for row in reader:
+        if not row:
+            continue
+        header = row[0].strip().upper()
+        if header == "DATE":
+            # reset accumulation for the data section
+            latest_date = None
+            latest_ratio = None
+            continue
+        if not row[0].strip():
+            continue
+        try:
+            parsed_date = dt.datetime.strptime(row[0].strip(), "%m/%d/%Y").date()
+        except ValueError:
+            continue
+        ratio = _parse_ratio(row[-1])
+        if ratio is None:
+            continue
+        if latest_date is None or parsed_date > latest_date:
+            latest_date = parsed_date
+            latest_ratio = ratio
+    if latest_date is None or latest_ratio is None:
+        raise RuntimeError("CSV 缺少有效的日期或比值")
+    return latest_date.isoformat(), latest_ratio
+
+
+def _fetch_csv_ratios(session: requests.Session) -> Tuple[Dict[str, float], Optional[str], List[str]]:
+    ratios: Dict[str, float] = {}
+    dates: List[str] = []
+    errors: List[str] = []
+    for key, url in CSV_SOURCES.items():
+        try:
+            resp = session.get(url, timeout=REQUEST_TIMEOUT)
+            resp.raise_for_status()
+            date_str, ratio = _latest_csv_row(resp.text)
+            ratios[key] = ratio
+            dates.append(date_str)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"{key}: {exc}")
+    unique_dates = sorted(set(dates), reverse=True)
+    return ratios, (unique_dates[0] if unique_dates else None), errors
+
+
+def _fetch_total_today(session: requests.Session) -> Optional[float]:
+    try:
+        resp = session.get(MARKET_SUMMARY_URL, timeout=REQUEST_TIMEOUT)
+        resp.raise_for_status()
+    except Exception:  # noqa: BLE001
+        return None
+    match = TOTAL_PATTERN.search(resp.text)
+    if not match:
+        return None
+    try:
+        return float(match.group(1))
+    except ValueError:
+        return None
 
 
 def fetch() -> Tuple[Dict[str, Dict[str, object]], FetchStatus]:
-    """Fetch put/call ratios from the Cboe daily statistics page."""
+    """Fetch put/call ratios from the published CSV archives."""
 
-    headers = {"User-Agent": USER_AGENT}
-    try:
-        response = requests.get(URL, headers=headers, timeout=REQUEST_TIMEOUT)
-        response.raise_for_status()
-    except Exception as exc:  # noqa: BLE001
-        return {}, FetchStatus(name="cboe_put_call", ok=False, message=f"Cboe 请求失败: {exc}")
-
-    parser = _TextExtractor()
-    parser.feed(response.text)
-    text = parser.get_text()
-    ratios = _extract_numbers(text)
+    session = _init_session()
+    ratios, date_str, errors = _fetch_csv_ratios(session)
 
     if not ratios:
-        return {}, FetchStatus(name="cboe_put_call", ok=False, message="未能解析 Put/Call 数据")
+        total_ratio = _fetch_total_today(session)
+        if total_ratio is not None:
+            ratios["total"] = total_ratio
+            message = "Cboe 总体 Put/Call 使用当日页面兜底"
+        else:
+            detail = "; ".join(errors) if errors else "未能获取 Cboe 数据"
+            return {}, FetchStatus(name="cboe_put_call", ok=False, message=detail)
+    else:
+        message = "Cboe Put/Call CSV 数据已更新"
 
     now_ct = dt.datetime.now(tz=EXCHANGE_TZ)
     payload: Dict[str, Dict[str, object]] = {
         "put_call": {
-            "as_of_exchange_tz": "America/Chicago",
+            "as_of_exchange_tz": EXCHANGE_TZ.key,
             "as_of_utc": now_ct.astimezone(ZoneInfo("UTC")).isoformat().replace("+00:00", "Z"),
-            "source": "cboe_daily_market_statistics",
+            "source": "cboe_volume_put_call_csv",
         }
     }
+    if date_str:
+        payload["put_call"]["as_of_date"] = date_str
     payload["put_call"].update(ratios)
 
-    return payload, FetchStatus(
-        name="cboe_put_call",
-        ok=True,
-        message="Cboe Put/Call 数据已更新",
-    )
+    if errors and ratios:
+        message = f"{message}（部分字段缺失: {'; '.join(errors)}）"
+
+    return payload, FetchStatus(name="cboe_put_call", ok=True, message=message)


### PR DESCRIPTION
## Summary
- pull Cboe put/call ratios from the CDN CSV feeds with graceful degradation to the market statistics page
- read AAII sentiment directly from the Insights RSS feed and article body with a browser user agent
- harden FMP theme quote fetching and Bitcoin ETF flow ingestion with stable endpoints, retries, and HTML fallbacks

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e678a648b08327870bc54de6d6cb59